### PR TITLE
Adding a shortcut option for toggling scroll in the current tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /web-ext-artifacts
 test/kill-server.sh
 .web-extension-id
-/public
+/dist
 
 Session.vim
 

--- a/manifest.json
+++ b/manifest.json
@@ -48,7 +48,7 @@
   "commands": {
     "toggle-scrolling-state": {
       "suggested_key": {
-        "default": "Ctrl+Shift+PageDown"
+        "default": "Alt+Shift+PageDown"
       },
       "description": "Sends a command to toggle the Autoscrolling ON or OFF"
     }

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
 
   "description": "Auto-scrolling without mouse-wheel",
 
-  "permissions": [ "storage" ],
+  "permissions": ["storage"],
 
   "options_ui": {
     "page": "dist/options.html"
@@ -35,13 +35,22 @@
 
   "content_scripts": [
     {
-      "matches": [ "<all_urls>" ],
-      "js": [ "dist/content.js" ],
-      "css": [ "dist/index.css" ]
+      "matches": ["<all_urls>"],
+      "js": ["dist/content.js"],
+      "css": ["dist/index.css"]
     }
   ],
 
   "background": {
-    "scripts": [ "dist/background.js" ]
+    "scripts": ["dist/background.js"]
+  },
+
+  "commands": {
+    "toggle-scrolling-state": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+PageDown"
+      },
+      "description": "Sends a command to toggle the Autoscrolling ON or OFF"
+    }
   }
 }

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -59,10 +59,10 @@ function toggleAutoScrolling (tab) {
   // function is not called.
   const tabId = tab.id;
   const windowId = tab.windowId;
-  const willIsScrolling = ! autoScrollingStates[ windowId ].isScrolling;
+  const willIsScrolling = !(autoScrollingStates[ windowId ] && autoScrollingStates[ windowId ].isScrolling);
   browser.tabs.sendMessage(tabId, {
     isScrolling: willIsScrolling
-  }).then((response) => {
+  }).then(() => {
     autoScrollingStates[ windowId ].tabId = tabId;
     autoScrollingStates[ windowId ].isScrolling = willIsScrolling;
   }).catch(onError);
@@ -107,10 +107,15 @@ function resetIsWaitingDoubleClick (windowId) {
 
 // Listens for all of the available and assignable keyboard shortcut commands.
 browser.commands.onCommand.addListener(function(command) {
-  const currentTab = browser.tabs.getCurrent();
-  if (command == 'toggle-scrolling-state') {
-    toggleAutoScrolling(currentTab);
-  }
+  // https://stackoverflow.com/questions/43695817/tabs-getcurrent-result-is-undefined
+  browser.tabs.query({active: true, windowId: browser.windows.WINDOW_ID_CURRENT})
+    .then(tabs => browser.tabs.get(tabs[0].id))
+    .then(currentTab => {
+      if (command == 'toggle-scrolling-state') {
+        toggleAutoScrolling(currentTab);
+      }
+    })
+    .catch(onError);
 });
 
 browser.windows.onCreated.addListener((window) => {

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -105,6 +105,14 @@ function resetIsWaitingDoubleClick (windowId) {
 //////////////////////////////////////////////////////////////////////////////
 // Event listeners / event functions
 
+// Listens for all of the available and assignable keyboard shortcut commands.
+browser.commands.onCommand.addListener(function(command) {
+  const currentTab = browser.tabs.getCurrent();
+  if (command == 'toggle-scrolling-state') {
+    toggleAutoScrolling(currentTab);
+  }
+});
+
 browser.windows.onCreated.addListener((window) => {
   const windowId = window.id;
   createAutoScrollingState(windowId);

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -22,10 +22,10 @@
       </div>
       <div>
         <h2>Toggle the tab's scrolling by keyboard shortcut</h2>
-        <p>The value should be a combination of keycodes combined with the '+' sign. Ex: Ctrl+E.</p>
+        <p>The value should be a combination of keycodes combined with the '+' sign. <i>Ex: Ctrl+E.</i></p>
         <p>Check out the link for the keycodes: <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Key_combinations" target="_blank">Key combinations</a></p>
         <p><strong>Shortcut: Toggle Autoscrolling for the current tab</strong>
-        <input type="text" id="kb-shortcut-toggle-current-tab" value="Ctrl+Shift+PageDown" />
+        <input type="text" id="kb-shortcut-toggle-current-tab" value="Alt+Shift+PageDown" />
         </p>
       </div>
     </div>

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -9,15 +9,23 @@
         <h2>Scrolling speed</h2>
         <p>The value is scrolling speed. Max is 99, and min is 1.</p>
         <p><strong>Scrolling speed:</strong>
-          <input type="text" id="scrolling-speed" name="scrolling-speed" value=50 />
+        <input type="text" id="scrolling-speed" name="scrolling-speed" value=50 />
         </p>
       </div>
       <div>
         <h2>To stop scrolling by click</h2>
         <p>The value decides the weather stoppling the scrolling when you click the scrolling window.</p>
         <p><strong>Scrolling stop by click:</strong>
-          <input type="checkbox" id='stop-scrolling-by-click'
-            name='stop-scrolling-by-click' value=true checked=true />
+        <input type="checkbox" id='stop-scrolling-by-click'
+               name='stop-scrolling-by-click' value=true checked=true />
+        </p>
+      </div>
+      <div>
+        <h2>Toggle the tab's scrolling by keyboard shortcut</h2>
+        <p>The value should be a combination of keycodes combined with the '+' sign. Ex: Ctrl+E.</p>
+        <p>Check out the link for the keycodes: <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Key_combinations" target="_blank">Key combinations</a></p>
+        <p><strong>Shortcut: Toggle Autoscrolling for the current tab</strong>
+        <input type="text" id="kb-shortcut-toggle-current-tab" value="Ctrl+Shift+PageDown" />
         </p>
       </div>
     </div>

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -22,9 +22,10 @@
       </div>
       <div>
         <h2>Toggle the tab's scrolling by keyboard shortcut</h2>
-        <p>The value should be a combination of keycodes combined with the '+' sign. <i>Ex: Ctrl+E.</i></p>
+        <p>The value should be a combination of keycodes combined with the '+' sign. <i>Ex: Ctrl+Shift+Insert.</i></p>
         <p>Check out the link for the keycodes: <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Key_combinations" target="_blank">Key combinations</a></p>
-        <p><strong>Shortcut: Toggle Autoscrolling for the current tab</strong>
+        <p>PS: Some key combinations are reserved by the browser and can't be reassigned to this.</p>
+        <p><strong>Shortcut - Toggle Autoscrolling for the current tab: </strong>
         <input type="text" id="kb-shortcut-toggle-current-tab" value="Alt+Shift+PageDown" />
         </p>
       </div>

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -3,21 +3,35 @@
 
 import { onError } from '../utils';
 
+const updateKeyboardShortcut = (shortcutName, newShortcutCombination) => {
+  browser.commands.update(
+    {
+      name: shortcutName,
+      shortcut: newShortcutCombination 
+    }
+  ).catch(onError);
+};
+
 const setupOptionPage = () => {
   const scrollingSpeedEl =
     document.getElementById('scrolling-speed');
   const stopScrollingByClickEl =
     document.getElementById('stop-scrolling-by-click');
+  const shortcutToggleCurrentTab =
+    document.getElementById('kb-shortcut-toggle-current-tab');
 
   scrollingSpeedEl.addEventListener('change', setScrollingSpeed);
   stopScrollingByClickEl.addEventListener('change', setStopScrollingByClick);
+  shortcutToggleCurrentTab.addEventListener('blur', setShortcutForTogglingCurrentTab);
 
   browser.storage.sync.get({
     scrollingSpeed: 50,
-    stopScrollingByClick: true
+    stopScrollingByClick: true,
+    shortcutToggleCurrentTab: 'Ctrl+Shift+PageDown'
   }).then((options) => {
     scrollingSpeedEl.value = parseInt(options.scrollingSpeed);
     stopScrollingByClickEl.checked = options.stopScrollingByClick;
+    updateKeyboardShortcut('toggle-scrolling-state', options.shortcutToggleCurrentTab);
   });
 };
 
@@ -35,6 +49,11 @@ const setScrollingSpeed = (ev) => {
 const setStopScrollingByClick = (ev) => {
   let stopScrollingByClick = ev.target.checked;
   browser.storage.sync.set({ stopScrollingByClick: stopScrollingByClick });
+};
+
+const setShortcutForTogglingCurrentTab = (ev) => {
+  let shortcutToggleCurrentTab = ev.target.value;
+  browser.storage.sync.set({ shortcutToggleCurrentTab });
 };
 
 setupOptionPage();

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -11,7 +11,7 @@ const updateKeyboardShortcut = (shortcutName, newShortcutCombination) => {
       shortcut: newShortcutCombination 
     }
   ).catch(onError);
-  browser.storage.sync.set({ shortcutToggleCurrentTab });
+  browser.storage.sync.set({ shortcutName: newShortcutCombination });
 };
 
 const setupOptionPage = () => {
@@ -29,7 +29,7 @@ const setupOptionPage = () => {
   browser.storage.sync.get({
     scrollingSpeed: 50,
     stopScrollingByClick: true,
-    shortcutToggleCurrentTab: 'Alt+Shift+PageDown'
+    'toggle-scrolling-state': 'Alt+Shift+PageDown'
   }).then((options) => {
     scrollingSpeedEl.value = parseInt(options.scrollingSpeed);
     stopScrollingByClickEl.checked = options.stopScrollingByClick;

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -4,14 +4,15 @@
 import { onError } from '../utils';
 
 const updateKeyboardShortcut = (shortcutName, newShortcutCombination) => {
-  console.log('Updating', shortcutName, newShortcutCombination);
   browser.commands.update(
     {
       name: shortcutName,
       shortcut: newShortcutCombination 
     }
   ).catch(onError);
-  browser.storage.sync.set({ shortcutName: newShortcutCombination });
+  let updateObject = {};
+  updateObject[shortcutName] = newShortcutCombination;
+  browser.storage.sync.set(updateObject);
 };
 
 const setupOptionPage = () => {
@@ -29,11 +30,12 @@ const setupOptionPage = () => {
   browser.storage.sync.get({
     scrollingSpeed: 50,
     stopScrollingByClick: true,
-    'toggle-scrolling-state': 'Alt+Shift+PageDown'
+    'toggle-scrolling-state': 'Alt+Shift+PageDown' 
   }).then((options) => {
     scrollingSpeedEl.value = parseInt(options.scrollingSpeed);
     stopScrollingByClickEl.checked = options.stopScrollingByClick;
-    updateKeyboardShortcut('toggle-scrolling-state', options.shortcutToggleCurrentTab);
+    shortcutToggleCurrentTabEl.value = options['toggle-scrolling-state'];
+    updateKeyboardShortcut('toggle-scrolling-state', options['toggle-scrolling-state']);
   });
 };
 

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -4,12 +4,14 @@
 import { onError } from '../utils';
 
 const updateKeyboardShortcut = (shortcutName, newShortcutCombination) => {
+  console.log('Updating', shortcutName, newShortcutCombination);
   browser.commands.update(
     {
       name: shortcutName,
       shortcut: newShortcutCombination 
     }
   ).catch(onError);
+  browser.storage.sync.set({ shortcutToggleCurrentTab });
 };
 
 const setupOptionPage = () => {
@@ -17,17 +19,17 @@ const setupOptionPage = () => {
     document.getElementById('scrolling-speed');
   const stopScrollingByClickEl =
     document.getElementById('stop-scrolling-by-click');
-  const shortcutToggleCurrentTab =
+  const shortcutToggleCurrentTabEl =
     document.getElementById('kb-shortcut-toggle-current-tab');
 
   scrollingSpeedEl.addEventListener('change', setScrollingSpeed);
   stopScrollingByClickEl.addEventListener('change', setStopScrollingByClick);
-  shortcutToggleCurrentTab.addEventListener('blur', setShortcutForTogglingCurrentTab);
+  shortcutToggleCurrentTabEl.addEventListener('blur', setShortcutForTogglingCurrentTab);
 
   browser.storage.sync.get({
     scrollingSpeed: 50,
     stopScrollingByClick: true,
-    shortcutToggleCurrentTab: 'Ctrl+Shift+PageDown'
+    shortcutToggleCurrentTab: 'Alt+Shift+PageDown'
   }).then((options) => {
     scrollingSpeedEl.value = parseInt(options.scrollingSpeed);
     stopScrollingByClickEl.checked = options.stopScrollingByClick;
@@ -52,8 +54,8 @@ const setStopScrollingByClick = (ev) => {
 };
 
 const setShortcutForTogglingCurrentTab = (ev) => {
-  let shortcutToggleCurrentTab = ev.target.value;
-  browser.storage.sync.set({ shortcutToggleCurrentTab });
+  let kbShortcut = ev.target.value;
+  updateKeyboardShortcut('toggle-scrolling-state', kbShortcut);
 };
 
 setupOptionPage();

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const onError = (err) => {
-  console.error(`Error: ${err}`);
+  console.error(`Autoscrolling Error: ${err}`);
 };
 
 export { onError };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 const src = path.resolve(__dirname, 'src');
-const public = path.resolve(__dirname, 'public');
+const dist = path.resolve(__dirname, 'dist');
 
 module.exports = {
   entry: {
@@ -14,7 +14,7 @@ module.exports = {
   },
 
   output: {
-    path: public,
+    path: dist,
     filename: '[name].js'
   },
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 const src = path.resolve(__dirname, 'src');
-const dist = path.resolve(__dirname, 'public');
+const public = path.resolve(__dirname, 'public');
 
 module.exports = {
   entry: {
@@ -14,7 +14,7 @@ module.exports = {
   },
 
   output: {
-    path: dist,
+    path: public,
     filename: '[name].js'
   },
 


### PR DESCRIPTION
The main intent here is to add a configurable keyboard shortcut for enabling/disabling Autoscrolling in the current tab.

Very useful in Full Screen because you don't see the button for toggling it, but also quicker to turn ON/OFF.

**Changes:**
- Adding a field to the addon's option page for configuring the shortcut.
- Registering the default shortcut for toggling Autoscrolling in the manifest file.
- Renaming the directory in the webpack configuration back to dist (the way you had set up wasn't working for me, maybe it's because I'm on a different system?).

This is my first time with WebExtensions so feel invited to correct me if I've made some mistake.
                                : - )
